### PR TITLE
Store firmware information

### DIFF
--- a/static/firmware/firmware-fox.json
+++ b/static/firmware/firmware-fox.json
@@ -1,7 +1,8 @@
 [
     {
         "version": "0.1.4-esp-idf.1+build.0",
-        "url": "https://github.com/MathyV/fri3d_firmware/releases/download/v0.1.4/fri3d_firmware_fox.bin"
+        "url": "https://github.com/MathyV/fri3d_firmware/releases/download/v0.1.4/fri3d_firmware_fox.bin",
+        "size": 1396496
     }
 ]
 

--- a/static/firmware/firmware-fox.json
+++ b/static/firmware/firmware-fox.json
@@ -1,0 +1,7 @@
+[
+    {
+        "version": "0.1.4-esp-idf.1+build.0",
+        "url": "https://github.com/MathyV/fri3d_firmware/releases/download/v0.1.4/fri3d_firmware_fox.bin"
+    }
+]
+

--- a/static/firmware/firmware-octopus.json
+++ b/static/firmware/firmware-octopus.json
@@ -1,7 +1,8 @@
 [
     {
         "version": "0.1.4-esp-idf.1+build.0",
-        "url": "https://github.com/MathyV/fri3d_firmware/releases/download/v0.1.4/fri3d_firmware_octopus.bin"
+        "url": "https://github.com/MathyV/fri3d_firmware/releases/download/v0.1.4/fri3d_firmware_octopus.bin",
+        "size": 1448512
     }
 ]
 

--- a/static/firmware/firmware-octopus.json
+++ b/static/firmware/firmware-octopus.json
@@ -1,0 +1,7 @@
+[
+    {
+        "version": "0.1.4-esp-idf.1+build.0",
+        "url": "https://github.com/MathyV/fri3d_firmware/releases/download/v0.1.4/fri3d_firmware_octopus.bin"
+    }
+]
+


### PR DESCRIPTION
We need a stable location to store the information on firmware updates, we tried using Github API's directly but it didn't work properly as they have API limits. Only the .json needs to be stored, we can pull the binaries directly from Github without limitations.
