### PR TITLE
Replace first firmware with the one installed on Fox badges before camp

### DIFF
--- a/static/firmware/firmware-fox.json
+++ b/static/firmware/firmware-fox.json
@@ -1,8 +1,8 @@
 [
     {
-        "version": "0.1.4-esp-idf.1+build.0",
-        "url": "https://github.com/MathyV/fri3d_firmware/releases/download/v0.1.4/fri3d_firmware_fox.bin",
-        "size": 1396496
+        "version": "0.1.5-esp-idf.1+build.0",
+        "url": "https://github.com/MathyV/fri3d_firmware/releases/download/v0.1.5/fri3d_firmware_fox.bin",
+        "size": 1395200
     }
 ]
 

--- a/static/firmware/firmware-octopus.json
+++ b/static/firmware/firmware-octopus.json
@@ -1,8 +1,8 @@
 [
     {
-        "version": "0.1.4-esp-idf.1+build.0",
-        "url": "https://github.com/MathyV/fri3d_firmware/releases/download/v0.1.4/fri3d_firmware_octopus.bin",
-        "size": 1448512
+        "version": "0.1.5-esp-idf.1+build.0",
+        "url": "https://github.com/MathyV/fri3d_firmware/releases/download/v0.1.5/fri3d_firmware_octopus.bin",
+        "size": 1447232
     }
 ]
 


### PR DESCRIPTION
There were some issues with OTA code still in 0.1.4, this way they won't make it back on visitors' badges